### PR TITLE
Avoid one exec when handling help action or no argument situation

### DIFF
--- a/bin/rip
+++ b/bin/rip
@@ -26,6 +26,8 @@
 ##    $ rip exec RIPENV command_to_run_under_ripenv
 ##
 
+ARGV.replace(['--help']) if ARGV.empty? || ARGV[0] == "help"
+
 while ARGV[0] =~ /^-/
   case ARGV.shift
   when /--ripdir=(.+)/
@@ -45,7 +47,6 @@ while ARGV[0] =~ /^-/
   end
 end
 
-exec "rip --help" if ARGV.empty? || ARGV[0] == "help"
 begin
   exec "rip-#{ARGV.shift}", *ARGV
 rescue Errno::ENOENT


### PR DESCRIPTION
This saves an exec call, and when environment is not set up as described in readme user will still get help output instead of an unhelpful error message.
